### PR TITLE
Fix spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # audioconvertyt
-Audio convertor
+Audio converter


### PR DESCRIPTION
## Summary
- fix `Audio convertor` spelling in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684325165f28832683b5e6043f0a88c2